### PR TITLE
Publish locally to `.m2` and avoid having an `unmanagedBase` directory. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,82 @@
+# Created by https://www.gitignore.io
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+
+### SBT ###
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+target/
+lib_managed/
+src_managed/
+project/boot/
+.history
+.cache
+
+
+### Scala ###
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: scala
+scala:
+- 2.11.6
+- 2.10.4
+script: sbt clean publish

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "CoreNLP-Scala"
 
-organization := "com.github.mrmechko"
+organization := "com.github.gangeli"
 
 scalaVersion := "2.11.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,9 @@
 name := "CoreNLP-Scala"
 
+organization := "com.github.mrmechko"
+
+scalaVersion := "2.11.6"
+
 version := "1.0"
 
 scalaSource in Compile := baseDirectory.value / "src"
@@ -12,3 +16,7 @@ libraryDependencies ++= Seq(
   "edu.stanford.nlp" % "stanford-corenlp" % "3.4" classifier "models",
   "edu.stanford.nlp" % "stanford-parser" % "3.4"
 )
+
+crossScalaVersions := Seq("2.10.4", "2.11.6")
+
+publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))


### PR DESCRIPTION
Closes #3.

For an example of how to automatically get this package in a relatively robust manner, see [mrmechko/senseval2](http://www.github.com/mrmechko/senseval2)
